### PR TITLE
Typo variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ It will attempt to spot:
  - Unexpected indentation
  - Single equals in boolean condition
 
+Setup
+-----
+
+Install requirements:
+
+```bash
+$ pip install -r requirements.txt
+```
+
 Name
 ----
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
 
     # Project uses reStructuredText, so ensure that the docutils get
     # installed or upgraded on the target machine
-    install_requires=['docutils>=0.3'],
+    install_requires=['docutils>=0.3', 'nltk'],
 
     package_data={
         # If any package contains *.txt or *.rst files, include them:

--- a/slips_lib/friendly_errors.py
+++ b/slips_lib/friendly_errors.py
@@ -1,0 +1,6 @@
+def print_code(code):
+	print('\t' + code)
+
+def print_bad_code(code, start_pos, length):
+	print_code(code)
+	print_code((" " * start_pos) + ("~" * length))

--- a/slips_lib/run_checks.py
+++ b/slips_lib/run_checks.py
@@ -1,26 +1,5 @@
 import ast
-import re
-import sys
-import traceback
-import nltk
-
-class FindAssignments(ast.NodeVisitor):
-	var_name = ''
-	best_distance = 0
-	best_guess = ''
-	def __init__(self, var_name):
-		self.var_name = var_name
-		self.best_distance = len(var_name) + 1
-
-	def visit_Assign(self, node):
-		for target in node.targets:
-			if isinstance(target, ast.Name):
-				target_name = target.id
-				distance = nltk.edit_distance(target_name, self.var_name)
-				if distance < self.best_distance:
-					self.best_distance = distance
-					self.best_guess = target_name
-
+import slips_lib.variable_name_typo
 
 def run_checks(file_path, source_code):
 	print('checking ' + file_path)
@@ -30,22 +9,6 @@ def run_checks(file_path, source_code):
 	try:
 		exec(result)
 	except NameError as name_error:
-		exc_type, exc_value, exc_traceback = sys.exc_info()
-		lines = source_code.split('\n')
-		line_no = traceback.extract_tb(exc_traceback, -1)[0].lineno
-		source_line = lines[line_no -1]
-		del(exc_type)
-		del(exc_value)
-		del(exc_traceback)
-		name_match = re.search('name \'(\w+)\' is not defined', str(name_error))
-		variable_name = name_match.group(1)
-		find_assignments = FindAssignments(variable_name)
-		find_assignments.visit(ast_value)
-		if len(find_assignments.best_guess) > 0:
-			start_pos = source_line.find(variable_name)
-			print('typo in variable name \'' + variable_name + '\'')
-			print('\t' + source_line + " (" + file_path + " line " + str(line_no) + ")")
-			print('\t' + (" " * start_pos) + ("~" * len(variable_name)))
-			print("Suggestion - replace with \'" + find_assignments.best_guess + '\':')
-			print('\t' + source_line.replace(variable_name, find_assignments.best_guess))
-
+		slips_lib.variable_name_typo.run(name_error, file_path, source_code, ast_value)
+		
+		

--- a/slips_lib/run_checks.py
+++ b/slips_lib/run_checks.py
@@ -1,2 +1,51 @@
+import ast
+import re
+import sys
+import traceback
+import nltk
+
+class FindAssignments(ast.NodeVisitor):
+	var_name = ''
+	best_distance = 0
+	best_guess = ''
+	def __init__(self, var_name):
+		self.var_name = var_name
+		self.best_distance = len(var_name) + 1
+
+	def visit_Assign(self, node):
+		for target in node.targets:
+			if isinstance(target, ast.Name):
+				target_name = target.id
+				distance = nltk.edit_distance(target_name, self.var_name)
+				if distance < self.best_distance:
+					self.best_distance = distance
+					self.best_guess = target_name
+
+
 def run_checks(file_path, source_code):
 	print('checking ' + file_path)
+
+	ast_value = ast.parse(source_code, file_path)
+	result = compile(source_code, file_path, 'exec')
+	try:
+		exec(result)
+	except NameError as name_error:
+		exc_type, exc_value, exc_traceback = sys.exc_info()
+		lines = source_code.split('\n')
+		line_no = traceback.extract_tb(exc_traceback, -1)[0].lineno
+		source_line = lines[line_no -1]
+		del(exc_type)
+		del(exc_value)
+		del(exc_traceback)
+		name_match = re.search('name \'(\w+)\' is not defined', str(name_error))
+		variable_name = name_match.group(1)
+		find_assignments = FindAssignments(variable_name)
+		find_assignments.visit(ast_value)
+		if len(find_assignments.best_guess) > 0:
+			start_pos = source_line.find(variable_name)
+			print('typo in variable name \'' + variable_name + '\'')
+			print('\t' + source_line + " (" + file_path + " line " + str(line_no) + ")")
+			print('\t' + (" " * start_pos) + ("~" * len(variable_name)))
+			print("Suggestion - replace with \'" + find_assignments.best_guess + '\':')
+			print('\t' + source_line.replace(variable_name, find_assignments.best_guess))
+

--- a/slips_lib/runtime_exception_parser.py
+++ b/slips_lib/runtime_exception_parser.py
@@ -1,0 +1,15 @@
+import sys
+import traceback
+
+def get_error_line_number():
+	exc_type, exc_value, exc_traceback = sys.exc_info()
+	line_no = traceback.extract_tb(exc_traceback, -1)[0].lineno
+	del(exc_type)
+	del(exc_value)
+	del(exc_traceback)
+	return line_no
+
+def get_error_line(source_code, line_no):
+	lines = source_code.split('\n')
+	source_line = lines[line_no -1]	
+	return source_line

--- a/slips_lib/variable_name_typo.py
+++ b/slips_lib/variable_name_typo.py
@@ -1,0 +1,43 @@
+import nltk
+import re
+import ast
+
+from slips_lib.friendly_errors import print_code
+from slips_lib.friendly_errors import print_bad_code
+import slips_lib.runtime_exception_parser
+
+class FindAssignments(ast.NodeVisitor):
+	var_name = ''
+	best_distance = 0
+	best_guess = ''
+	def __init__(self, var_name):
+		self.var_name = var_name
+		self.best_distance = len(var_name) + 1
+
+	def visit_Assign(self, node):
+		for target in node.targets:
+			if isinstance(target, ast.Name):
+				target_name = target.id
+				distance = nltk.edit_distance(target_name, self.var_name)
+				if distance < self.best_distance:
+					self.best_distance = distance
+					self.best_guess = target_name
+
+def get_variable_name(name_error):
+	name_match = re.search('name \'(\w+)\' is not defined', str(name_error))
+	variable_name = name_match.group(1)
+	return variable_name
+
+def run(name_error, file_path, soure_code, ast_value):
+	error_line_no = slips_lib.runtime_exception_parser.get_error_line_number()
+	source_line = slips_lib.runtime_exception_parser.get_error_line(soure_code, error_line_no)
+
+	variable_name = get_variable_name(name_error)
+	find_assignments = FindAssignments(variable_name)
+	find_assignments.visit(ast_value)
+	if len(find_assignments.best_guess) > 0: 
+		print('typo in variable name \'' + variable_name + '\'')
+		print_bad_code(source_line, source_line.find(variable_name), len(variable_name))
+		
+		print("Suggestion - replace with \'" + find_assignments.best_guess + '\':')
+		print_code(source_line.replace(variable_name, find_assignments.best_guess))

--- a/tests/variable_name_typo/test_variable_name_typos.py
+++ b/tests/variable_name_typo/test_variable_name_typos.py
@@ -1,0 +1,10 @@
+from subprocess import Popen, PIPE
+
+def test_variable_name():
+	process = Popen(["python3", "slips.py", "tests/variable_name_typo/wrong_named_variable.py"], stdout=PIPE)
+	(output, err) = process.communicate()
+	exit_code = process.wait()
+	output_str = output.decode('utf-8')
+	assert(output_str.find("typo in variable name 'varible'") != -1)
+	assert(output_str.find("\tif varible == 5:") != -1)
+	assert(output_str.find("Suggestion - replace with 'variable':") != -1)

--- a/tests/variable_name_typo/wrong_named_variable.py
+++ b/tests/variable_name_typo/wrong_named_variable.py
@@ -1,0 +1,4 @@
+variable = 4
+toher = 5
+if varible == 5:
+	print('yay')


### PR DESCRIPTION
Adds a check for typos in names. It works in the following way:

 - identify name errors 
 - find variable assignments with similar names 
 - suggest the closest matching name as the fix. 